### PR TITLE
Compile under macOS

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,14 @@
+## macOS
+
+Compilation has been tested on macOS Monterey 12.3.1.
+
+You'll need the XCode command-line tools and three packages installable with
+[Homebrew](https://brew.sh/):
+
+```
+brew install pkg-config sdl2 sdl2_net
+```
+
+It's best to set up `Z` and `X` for firing the left and right sidekicks, as the
+default binding of `Ctrl` for the left sidekick interacts with the arrow keys
+to switch desktops while playing in full screen mode.

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 # BUILD SETTINGS ###############################################################
 
+
+ifeq (Darwin, $(shell uname))
+    PLATFORM := UNIX
+    TYRIAN_DIR = $(gamesdir)/opentyrian2000
+else
 ifneq ($(filter Msys Cygwin, $(shell uname -o)), )
     PLATFORM := WIN32
     TYRIAN_DIR = C:\\TYRIAN
 else
     PLATFORM := UNIX
     TYRIAN_DIR = $(gamesdir)/opentyrian2000
+endif
 endif
 
 WITH_NETWORK := true


### PR DESCRIPTION
436bdb8fcd0260dd2a53d23f0282162fc2a9724f removed OSX project files back in 2014.

However, it's really easy to compile this project for macOS using the current Makefile.  This PR adds a Darwin check to the makefile as `uname` doesn't have a `-o` option on macOS.  Once this check is in place, `make` compiles the project with no warnings.  This PR also adds a quick `BUILDING.md` that currently documents how to build on macOS.