### PR TITLE
Add General MIDI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ tyrian.sav
 
 # Doxygen output
 /doc/doxygen/
+
+tyrian2000
+.vscode
+vcpkg_installed/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,48 @@
 
 ifneq ($(filter Msys Cygwin, $(shell uname -o)), )
     PLATFORM := WIN32
+    OS := win
     TYRIAN_DIR = C:\\TYRIAN
+else ifeq (Darwin, $(shell uname)) # macOS
+    PLATFORM := UNIX
+    OS := osx
+    TYRIAN_DIR = $(gamesdir)/opentyrian2000
 else
     PLATFORM := UNIX
+    OS := linux
     TYRIAN_DIR = $(gamesdir)/opentyrian2000
 endif
 
+# detect the architecture
+HOST_TRIPLET := $(shell $(CC) -dumpmachine)
+_ARCH := $(word 1, $(subst -, ,$(HOST_TRIPLET)))
+
+ifeq ($(_ARCH), aarch64)
+    ARCH := arm64
+else
+    ARCH := $(_ARCH)
+endif
+
+# check if VCPKG_TRIPLET, VCPKG_TARGET_TRIPLET, or VCPKG_DEFAULT_TRIPLET is set
+# if not, set it to the OS and ARCH
+ifneq ($(VCPKG_TRIPLET), )
+    $(info VCPKG_TRIPLET: $(VCPKG_TRIPLET))
+else ifneq ($(VCPKG_TARGET_TRIPLET), )
+    VCPKG_TRIPLET := $(VCPKG_TARGET_TRIPLET)
+else ifneq ($(VCPKG_DEFAULT_TRIPLET), )
+    VCPKG_TRIPLET := $(VCPKG_DEFAULT_TRIPLET)
+else
+    _VCPKG_TRIPLET := $(ARCH)-$(OS)
+    # if using windows, use the static-md triplet by default
+    ifeq ($(OS), win)
+        VCPKG_TRIPLET := $(_VCPKG_TRIPLET)-static-md
+    else
+        VCPKG_TRIPLET := $(_VCPKG_TRIPLET)
+    endif
+endif
+
 WITH_NETWORK := true
+WITH_MIDI := true
 
 ################################################################################
 
@@ -56,6 +91,14 @@ ifeq ($(WITH_NETWORK), true)
     EXTRA_CPPFLAGS += -DWITH_NETWORK
 endif
 
+ifeq ($(WITH_MIDI), true)
+    EXTRA_CPPFLAGS += -DWITH_MIDI
+endif
+
+ifeq ($(OS), linux)
+    EXTRA_CPPFLAGS += -DNO_NATIVE_MIDI
+endif
+
 OPENTYRIAN_VERSION := $(shell $(VCS_IDREV) 2>/dev/null && \
                               touch src/opentyrian_version.h)
 ifneq ($(OPENTYRIAN_VERSION), )
@@ -67,20 +110,57 @@ CPPFLAGS += -DNDEBUG
 CFLAGS ?= -pedantic \
           -Wall \
           -Wextra \
-          -Wno-format-truncation \
+          -Wno-strict-prototypes \
           -Wno-missing-field-initializers \
-          -O2
+          -O3
+
 LDFLAGS ?=
 LDLIBS ?=
 
-ifeq ($(WITH_NETWORK), true)
-    SDL_CPPFLAGS := $(shell $(PKG_CONFIG) sdl2 SDL2_net --cflags)
-    SDL_LDFLAGS := $(shell $(PKG_CONFIG) sdl2 SDL2_net --libs-only-L --libs-only-other)
-    SDL_LDLIBS := $(shell $(PKG_CONFIG) sdl2 SDL2_net --libs-only-l)
+libmidiconv_PC_PATH :=
+
+# check if the "vcpkg_installed" directory exists in the directory that this makefile is in
+# if it does, add it to the pkg-config search path=
+VCPKG_CHLDDIR := $(VCPKG_TRIPLET)/lib/pkgconfig
+ifeq ($(findstring debug, $(MAKECMDGOALS)), debug)
+    VCPKG_CHLDDIR := $(VCPKG_TRIPLET)/debug/lib/pkgconfig
+endif
+
+# local vcpkg
+ifneq ($(wildcard vcpkg_installed), )
+    VCPKG_PC_PATH := $(CURDIR)/vcpkg_installed/$(VCPKG_CHLDDIR)
+# global vcpkg
+else ifneq ($(VCPKG_ROOT), )
+    VCPKG_PC_PATH := $(VCPKG_ROOT)/installed/$(VCPKG_CHLDDIR)
+endif
+
+ifeq ($(PKG_CONFIG_PATH), )
+    PKG_CONFIG_PATH := $(VCPKG_PC_PATH):$(libmidiconv_PC_PATH):$(shell $(PKG_CONFIG) --variable pc_path pkg-config)
 else
-    SDL_CPPFLAGS := $(shell $(PKG_CONFIG) sdl2 --cflags)
-    SDL_LDFLAGS := $(shell $(PKG_CONFIG) sdl2 --libs-only-L --libs-only-other)
-    SDL_LDLIBS := $(shell $(PKG_CONFIG) sdl2 --libs-only-l)
+    PKG_CONFIG_PATH := $(VCPKG_PC_PATH):$(libmidiconv_PC_PATH):$(PKG_CONFIG_PATH)
+endif
+
+
+SDL_PACKAGES := sdl2
+MIDIPROC_LIBS :=
+PC_CMD := PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG)
+
+ifeq ($(WITH_NETWORK), true)
+    SDL_PACKAGES += SDL2_net
+endif
+
+ifeq ($(WITH_MIDI), true)
+    SDL_PACKAGES += SDL2_mixer_ext
+    MIDIPROC_LIBS := midiproc fluidsynth
+endif
+
+SDL_CPPFLAGS := $(shell $(PC_CMD) $(SDL_PACKAGES) $(MIDIPROC_LIBS) --cflags)
+SDL_LDFLAGS := $(shell $(PC_CMD) $(SDL_PACKAGES) $(MIDIPROC_LIBS) --libs-only-L --libs-only-other)
+SDL_LDLIBS := $(shell $(PC_CMD) $(SDL_PACKAGES) $(MIDIPROC_LIBS) --libs-only-l)
+
+# add stdc++ to the ldlibs if using midiproc
+ifneq ($(MIDIPROC_LIBS), )
+    SDL_LDLIBS += -lstdc++
 endif
 
 ALL_CPPFLAGS = -DTARGET_$(PLATFORM) \

--- a/ports/midiproc/portfile.cmake
+++ b/ports/midiproc/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nikitalita/midiproc
+    REF "${VERSION}"
+    SHA512 aa885281d92197f68cc12d1b61d2b37f6860f6d54b8e3ed9a6eb6b1d805ccdb0d497f790be76e0482c348961e20550d8cc1979cc574f3a3863dfa7228265c333
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME midiproc
+    CONFIG_PATH lib/cmake/midiproc)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+)

--- a/ports/midiproc/vcpkg.json
+++ b/ports/midiproc/vcpkg.json
@@ -1,0 +1,32 @@
+{
+  "name": "midiproc",
+  "version": "0.1.0",
+  "description": "MIDI processing library",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "test": {
+      "description": "Enable tests",
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "host": true
+        },
+        {
+          "name": "sdl2-mixer-ext",
+          "features": ["fluidsynth"]
+        }
+      ]
+    }
+  },
+  "default-features": []
+}

--- a/src/config.c
+++ b/src/config.c
@@ -279,6 +279,29 @@ bool load_opentyrian_config(void)
 			}
 		}
 	}
+	section = config_find_section(config, "music", NULL);
+	if (section != NULL)
+	{
+		const char *music_device_name;
+		const char *soundfont_name;
+
+		if (config_get_string_option(section, "music_device", &music_device_name))
+		{
+			for (size_t i = 0; i < COUNTOF(music_device_names); ++i)
+			{
+				if (strcmp(music_device_name, music_device_names[i]) == 0)
+				{
+					music_device = i;
+					break;
+				}
+			}
+		}
+
+		if (config_get_string_option(section, "soundfont", &soundfont_name))
+			strncpy(soundfont, soundfont_name, MAX(strlen(soundfont_name) + 1, 4096));
+		
+		
+	}
 
 	fclose(file);
 	
@@ -327,6 +350,13 @@ bool save_opentyrian_config(void)
 	for (size_t i = 0; i < COUNTOF(mouseSettings); ++i)
 		config_set_string_option(section, mouseSettingNames[i], mouseSettingValues[mouseSettings[i] - 1]);
 
+	section = config_find_or_add_section(config, "music", NULL);
+	if (section == NULL)
+		exit(EXIT_FAILURE);  // out of memory
+
+	config_set_string_option(section, "music_device", music_device_names[music_device]);
+	config_set_string_option(section, "soundfont", soundfont);
+	
 	FILE *file = dir_fopen(get_user_directory(), "opentyrian.cfg", "w");
 	if (file == NULL)
 		return false;

--- a/src/helptext.c
+++ b/src/helptext.c
@@ -109,7 +109,7 @@ void read_encrypted_pascal_string(char *s, size_t size, FILE *f)
 
 	decrypt_string(buffer, len);
 
-	assert(len < size);
+	//assert(len < size);
 
 	len = MIN(len, size - 1);
 	memcpy(s, buffer, len);

--- a/src/loudness.h
+++ b/src/loudness.h
@@ -29,10 +29,22 @@ extern int audioSampleRate;
 extern unsigned int song_playing;
 
 extern bool audio_disabled, music_disabled, samples_disabled;
+extern char soundfont[4096];
+
+typedef enum {
+    OPL,
+    FLUIDSYNTH,
+    NATIVE_MIDI,
+    MUSIC_DEVICE_MAX
+} MusicDevice;
+
+extern MusicDevice music_device;
+
+extern const char *const music_device_names[MUSIC_DEVICE_MAX];
 
 bool init_audio(void);
 void deinit_audio(void);
-
+bool restart_audio(void);
 void load_music(void);
 void play_song(unsigned int song_num);
 void restart_song(void);

--- a/src/opentyr.c
+++ b/src/opentyr.c
@@ -97,6 +97,31 @@ static const char *getScalingModePickerItem(size_t i, char *buffer, size_t buffe
 	return scaling_mode_names[i];
 }
 
+static size_t getMusicDevicePickerItemsCount(void)
+{
+#ifndef WITH_MIDI
+	return (size_t)1;
+#else
+	#ifdef NO_NATIVE_MIDI
+	return (size_t)MUSIC_DEVICE_MAX - 1;
+	#else
+	return (size_t)MUSIC_DEVICE_MAX;
+	#endif
+#endif
+}
+
+static const char *getMusicDevicePickerItem(size_t i, char *buffer, size_t bufferSize)
+{
+	(void)buffer, (void)bufferSize;
+#ifndef WITH_MIDI
+	(void)i;
+	return music_device_names[0];
+#else
+	return music_device_names[i];
+#endif
+}
+
+
 void setupMenu(void)
 {
 	typedef enum
@@ -112,6 +137,7 @@ void setupMenu(void)
 		MENU_ITEM_SCALING_MODE,
 		MENU_ITEM_MUSIC_VOLUME,
 		MENU_ITEM_SOUND_VOLUME,
+		MENU_ITEM_MUSIC_DEVICE,
 	} MenuItemId;
 
 	typedef enum
@@ -164,6 +190,7 @@ void setupMenu(void)
 			.items = {
 				{ MENU_ITEM_MUSIC_VOLUME, "Music Volume", "Change volume with the left/right arrow keys." },
 				{ MENU_ITEM_SOUND_VOLUME, "Sound Volume", "Change volume with the left/right arrow keys." },
+				{ MENU_ITEM_MUSIC_DEVICE, "Music Device", "Change the music device.", getMusicDevicePickerItemsCount, getMusicDevicePickerItem},
 				{ MENU_ITEM_DONE, "Done", "Return to the previous menu." },
 				{ -1 }
 			},
@@ -271,6 +298,10 @@ void setupMenu(void)
 				JE_rectangle(VGAScreen, xMenuItemValue - 2, y - 2, xMenuItemValue + 96, y + 11, 242);
 				break;
 
+			case MENU_ITEM_MUSIC_DEVICE:
+				draw_font_hv_shadow(VGAScreen, xMenuItemValue, y, music_device_names[music_device], normal_font, left_aligned, 15, -3 + (selected ? 2 : 0) + (disabled ? -4 : 0), false, 2);
+				break;
+
 			default:
 				break;
 			}
@@ -376,6 +407,7 @@ void setupMenu(void)
 									case MENU_ITEM_DISPLAY:
 									case MENU_ITEM_SCALER:
 									case MENU_ITEM_SCALING_MODE:
+									case MENU_ITEM_MUSIC_DEVICE:
 									{
 										action = true;
 										break;
@@ -584,6 +616,14 @@ void setupMenu(void)
 					pickerSelectedIndex = scaling_mode;
 					break;
 				}
+				case MENU_ITEM_MUSIC_DEVICE:
+				{
+					JE_playSampleNum(S_CLICK);
+
+					currentPicker = selectedMenuItemId;
+					pickerSelectedIndex = music_device;
+					break;
+				}
 				case MENU_ITEM_MUSIC_VOLUME:
 				{
 					JE_playSampleNum(S_CLICK);
@@ -733,6 +773,12 @@ void setupMenu(void)
 				case MENU_ITEM_SCALING_MODE:
 				{
 					scaling_mode = pickerSelectedIndex;
+					break;
+				}
+				case MENU_ITEM_MUSIC_DEVICE:
+				{
+					music_device = pickerSelectedIndex;
+					restart_audio();
 					break;
 				}
 				default:

--- a/src/params.c
+++ b/src/params.c
@@ -51,6 +51,7 @@ void JE_paramCheck(int argc, char *argv[])
 		{ 'x', 'x', "no-xmas",           false },
 		
 		{ 't', 't', "data",              true },
+		{ 'f', 'f', "soundfont",         true },
 		
 		{ 'n', 'n', "net",               true },
 		{ 256, 0,   "net-player-name",   true }, // TODO: no short codes because there should
@@ -98,7 +99,9 @@ void JE_paramCheck(int argc, char *argv[])
 			       "  --net-player-number=NUMBER   Sets local player number in a networked game\n"
 			       "                               (1 or 2)\n"
 			       "  -p, --net-port=PORT          Local port to bind (default is 1333)\n"
-			       "  -d, --net-delay=FRAMES       Set lag-compensation delay (default is 1)\n", argv[0]);
+			       "  -d, --net-delay=FRAMES       Set lag-compensation delay (default is 1)\n"
+				   "  -f, --soundfont=FILE         Set the soundfont for MIDI playback\n\n"
+				   , argv[0]);
 			exit(0);
 			break;
 			
@@ -106,7 +109,10 @@ void JE_paramCheck(int argc, char *argv[])
 			// Disables sound/music usage
 			audio_disabled = true;
 			break;
-			
+		case 'f':
+			// Set the soundfont for MIDI playback
+			strncpy(soundfont, option.arg, MAX(strlen(option.arg) + 1, 4096));
+			break;
 		case 'j':
 			// Disables joystick detection
 			ignore_joystick = true;

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,15 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "f4456c1b974131b8467c7371a3c302b7f58a99f2",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ],
+  "overlay-ports": ["./ports"]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,41 @@
+{
+  "name": "opentyrian2000",
+  "version": "2000.20240218",
+  "description": "OpenTyrian2000 is an open-source port of the DOS game Tyrian. It is a fork of OpenTyrian, with the end goal being to replicate the experience of Tyrian 2000 as closely as possible.",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "sdl2",
+      "host": true
+    }
+  ],
+  "features": {
+    "midi": {
+      "description": "Enable MIDI music support",
+      "dependencies": [
+        "midiproc",
+        {
+          "name": "sdl2-mixer-ext",
+          "features": [
+            "fluidsynth",
+            {
+              "name": "nativemidi",
+              "platform": "(windows & !uwp) | osx"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "default-features": [
+    "midi"
+  ]
+}


### PR DESCRIPTION
Since it seems the parent repo maintainer is not interested in this, I decided to see if you would be:

This adds MIDI Support to OpenTyrian.

This is accomplished with the use of two third-party libraries and the use of vcpkg to install them.

In order to get something that played nice with SDL audio and had support for software synths like fluidsynth and the Native MIDI driver (for macOS and Windows), and ALSO allowed direct control of the mixer so that we could continue to use the same mixing we already had, I decided to use SDL-mixer-X, which is a fork of SDL-mixer that has a bunch more of the interface exposed and support for changing the MIDI backend at runtime.

I also needed a library to convert the LDS files to MIDI, so I decided to take foo_midi's integrated midi processing and spin it off into its own library.

Since those would be a pain to install since they're not packaged for distributions, I decided to use vcpkg to manage those dependencies. This is optional; you can just build them with cmake and install them as you would normally with cmake install.

If you want to use vcpkg, just install vcpkg and then run vcpkg install (vcpkg install --triplet x86_64-win-static-md on windows) in the working directory; the makefile will automatically find them using pkgconfig.

The vcpkg packages are version-pinned using the vcpkg-configuration.json file.